### PR TITLE
Refactored response with connection close token

### DIFF
--- a/RedfishEventListener_v1.py
+++ b/RedfishEventListener_v1.py
@@ -119,8 +119,10 @@ def process_data(newsocketconn, fromaddr):
                 if config['contextdetail'] is not None and outdata.get('Context', None) != config['contextdetail']:
                     my_logger.info("Context ({}) does not match with the server ({})."
                           .format(outdata.get('Context', None), config['contextdetail']))
-                StatusCode = """HTTP/1.1 200 OK\r\n\r\n"""
-                connstreamout.send(bytes(StatusCode, 'UTF-8'))
+                res = "HTTP/1.1 200 OK\r\n" \
+                      "Connection: close\r\n" \
+                      "\r\n"
+                connstreamout.send(res.encode())
                 with open(logfile, 'a') as f:
                     if 'EventTimestamp' in outdata:
                         receTime = datetime.now()


### PR DESCRIPTION
Send a "Connection: close" message in general header followed
status-code. It is a signal to sender that connection will be closed
after completion of the response.

Test:

- Apr 06 02:12:18 intel-obmc bmcweb[396]: (2022-04-06 02:12:18)
  [DEBUG "http_client.hpp":135] Connected to: 10.190.201.113:5008
- Apr 06 02:12:18 intel-obmc bmcweb[396]: (2022-04-06 02:12:18)
  [DEBUG "http_client.hpp":165] SSL Handshake successfull
- Apr 06 02:12:18 intel-obmc bmcweb[396]: (2022-04-06 02:12:18)
  [DEBUG "http_client.hpp":189] sendMessage() bytes transferred: 619
- Apr 06 02:12:19 intel-obmc bmcweb[396]: (2022-04-06 02:12:19)
  [DEBUG "http_client.hpp":224] recvMessage() bytes transferred: 38
- Apr 06 02:12:19 intel-obmc bmcweb[396]: (2022-04-06 02:12:19)
  [DEBUG "http_client.hpp":240] recvMessage() Header Response Code: 200
- Apr 06 02:12:19 intel-obmc bmcweb[396]: (2022-04-06 02:12:19)
  [DEBUG "http_client.hpp":263] recvMessage() keepalive : 0
- Apr 06 02:12:19 intel-obmc bmcweb[396]: (2022-04-06 02:12:19)
  [INFO "http_client.hpp":323] doClose(): Connection closed by server.
- Apr 06 02:12:19 intel-obmc bmcweb[396]: (2022-04-06 02:12:19)
  [DEBUG "http_client.hpp":459] requestDataQueue is empty

Signed-off-by: Hardik Panchal <hardikx.panchal@intel.com>

Fix #18 