### PR TITLE
Remove deprecated EventTypes and Expand properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The `SubscriptionDetails` section contains subscription information so that the 
 * `Destination`: The URI of the event listener.  The Redfish service will perform an HTTP POST on this URI to send events to the event listener.
 * `Context`: The context string to be transmitted back by the Redfish service when sending events.
 * `Format`: The format of the event notifications the event listener will receive.  Possible values are `Event` and `MetricReport`.
-* `Expand`: `true` indicates if the `OriginOfCondition` property will contain the expanded resource in the event payload.  `false` indicates no payload expansion.
 * `ResourceTypes`: An array of resource types the Redfish service will use to filter events for the event listener.  Some examples include `Chassis`, `Manager`, and `ComputerSystem`.
 * `Registries`: An array of registry names the Redfish service will use to filter events for the event listener.  Some examples include `ResourceEvent` and `TaskEvent`.
-* `EventTypes`: An array of classes of events the event listener will receive.  This setting has been deprecated by Redfish in favor of the above settings.  Possible values are `StatusChange`, `ResourceUpdated`, `ResourceAdded`, `ResourceRemoved`, `Alert`, `MetricReport`, and `Other`.
+
+Note: The `EventTypes` and `Expand` properties have been removed from `config.ini`. The `EventTypes` property was deprecated in Redfish v1.6.0.
 
 The `ServerInformation` section contains information about the Redfish services that will transmit events to the event listener.  All options in this section, except `LoginType`, are required.  The following options are found in this section:
 

--- a/RedfishEventListener_v1.py
+++ b/RedfishEventListener_v1.py
@@ -24,7 +24,7 @@ standard_out = logging.StreamHandler(sys.stdout)
 standard_out.setLevel(logging.INFO)
 my_logger.addHandler(standard_out)
 
-tool_version = '1.1.2'
+tool_version = '1.1.3'
 
 config = {
     'listenerip': '0.0.0.0',
@@ -214,8 +214,6 @@ if __name__ == '__main__':
     config['destination'] = parsed_config.get(my_config_key, 'Destination')
     if parsed_config.has_option(my_config_key, 'Context'):
         config['contextdetail'] = parsed_config.get(my_config_key, 'Context')
-    if parsed_config.has_option(my_config_key, 'EventTypes'):
-        config['eventtypes'] = parse_list(parsed_config.get(my_config_key, 'EventTypes'))
     if parsed_config.has_option(my_config_key, 'Format'):
         config['format'] = parsed_config.get(my_config_key, 'Format')
     if parsed_config.has_option(my_config_key, 'Expand'):
@@ -224,7 +222,7 @@ if __name__ == '__main__':
         config['resourcetypes'] = parse_list(parsed_config.get(my_config_key, 'ResourceTypes'))
     if parsed_config.has_option(my_config_key, 'Registries'):
         config['registries'] = parse_list(parsed_config.get(my_config_key, 'Registries'))
-    for k in ['format', 'expand', 'resourcetypes', 'registries', 'contextdetail', 'eventtypes']:
+    for k in ['format', 'resourcetypes', 'registries', 'contextdetail']:
         if config[k] in ['', [], None]:
             config[k] = None
 
@@ -260,11 +258,11 @@ if __name__ == '__main__':
                 my_ctx.login(auth=logintype.lower())
 
                 # Create the subscription
+                # Property "expand" was removed.
+                # Could not find any reference to this property in the DMTF standard v1.15.1.
                 response = redfish_utilities.create_event_subscription(my_ctx, config['destination'],
                                                                        client_context=config['contextdetail'],
-                                                                       event_types=config['eventtypes'],
                                                                        format=config['format'],
-                                                                       expand=config['expand'],
                                                                        resource_types=config['resourcetypes'],
                                                                        registries=config['registries'])
 

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 [Information]
-Updated = April 24, 2017
+Updated = July 10, 2022
 Description = Redfish Event Listener Tool
 
 [SystemInformation]
@@ -13,15 +13,8 @@ keyfile = server.key
 
 [SubscriptionDetails]
 Destination = https://<IP>/
-EventTypes = [
-    "Alert",
-    "ResourceRemoved",
-    "ResourceAdded" ,
-    "ResourceUpdated",
-    "StatusChange"]
 Context = Public
 Format = Event
-Expand = false
 ResourceTypes = ["Chassis"]
 Registries =
 


### PR DESCRIPTION
- Remove reference to EventTypes, as this property was deprecated in Redfish 1.6.
- Remove reference to Expand property.  Cannot determine that this property was ever part of the standard.
- Bump tool version.
- Update REAMDE

I think these changes would make it easier for anyone just adopting this tool. Both of these properties cause errors when trying to subscribe to Redfish devices, one of which has firmware that is two years old but still doesn't like these properties.

Signed-off-by: Roy Main <roy.main@hpe.com>