### PR TITLE
Fix spelling, remove references to 'subscription'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## [1.1.3] - 2022-07-11
-- Corrected spelling of 'subscription'. Remove if-else referencing old spelling.
-
-
 ## [1.1.2] - 2022-06-02
 - Corrected usage of 'lower' method for the authentication type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.1.3] - 2022-07-11
+- Corrected spelling of 'subscription'. Remove if-else referencing old spelling.
+
+
 ## [1.1.2] - 2022-06-02
 - Corrected usage of 'lower' method for the authentication type
 

--- a/RedfishEventListener_v1.py
+++ b/RedfishEventListener_v1.py
@@ -24,7 +24,7 @@ standard_out = logging.StreamHandler(sys.stdout)
 standard_out.setLevel(logging.INFO)
 my_logger.addHandler(standard_out)
 
-tool_version = '1.1.2'
+tool_version = '1.1.3'
 
 config = {
     'listenerip': '0.0.0.0',
@@ -207,10 +207,7 @@ if __name__ == '__main__':
         config['keyfile'] = parsed_config.get('CertificateDetails', 'keyfile')
 
     # Subscription Details
-    if parsed_config.has_section("SubsciptionDetails") and parsed_config.has_section("SubscriptionDetails"):
-        my_logger.error('Use either SubsciptionDetails or SubscriptionDetails in config, not both.')
-        sys.exit(1)
-    my_config_key = "SubsciptionDetails" if parsed_config.has_section("SubsciptionDetails") else "SubscriptionDetails"
+    my_config_key = "SubscriptionDetails"
     config['destination'] = parsed_config.get(my_config_key, 'Destination')
     if parsed_config.has_option(my_config_key, 'Context'):
         config['contextdetail'] = parsed_config.get(my_config_key, 'Context')
@@ -270,7 +267,7 @@ if __name__ == '__main__':
 
                 # Save the subscription info for deleting later
                 my_location = response.getheader('Location')
-                my_logger.info("Subcription is successful for {}, {}".format(dest, my_location))
+                my_logger.info("Subscription is successful for {}, {}".format(dest, my_location))
                 unsub_id = None
                 try:
                     # Response bodies are expected to have the event destination

--- a/RedfishEventListener_v1.py
+++ b/RedfishEventListener_v1.py
@@ -24,7 +24,7 @@ standard_out = logging.StreamHandler(sys.stdout)
 standard_out.setLevel(logging.INFO)
 my_logger.addHandler(standard_out)
 
-tool_version = '1.1.3'
+tool_version = '1.1.2'
 
 config = {
     'listenerip': '0.0.0.0',
@@ -207,7 +207,11 @@ if __name__ == '__main__':
         config['keyfile'] = parsed_config.get('CertificateDetails', 'keyfile')
 
     # Subscription Details
-    my_config_key = "SubscriptionDetails"
+    # Note: Older versions of the tool contained a spelling error for 'Subscription'; need to support both variants to maintain compatibility with older config files
+    if parsed_config.has_section("SubsciptionDetails") and parsed_config.has_section("SubscriptionDetails"):
+        my_logger.error('Use either SubsciptionDetails or SubscriptionDetails in config, not both.')
+        sys.exit(1)
+    my_config_key = "SubsciptionDetails" if parsed_config.has_section("SubsciptionDetails") else "SubscriptionDetails"
     config['destination'] = parsed_config.get(my_config_key, 'Destination')
     if parsed_config.has_option(my_config_key, 'Context'):
         config['contextdetail'] = parsed_config.get(my_config_key, 'Context')


### PR DESCRIPTION
Another one I noticed:

- Remove if/else checking for _Subcription_ (without R) heading of config.ini
- Correct spelling of _subscription_ in logger string
- Bump version

I believe this one can be removed with no side effects as config.ini will be read each time the script is started - granted that the user must update any old version of config.ini (which they get for free on any new fetch).

Signed-off-by: Roy Main <roy.main@hpe.com>