### PR TITLE
Add ListenerAuthentication to Sample Configuration with All Options Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Expand = false
 ResourceTypes = ["Chassis"]
 Registries = ["ResourceEvent"]
 
+[ListenerAuthentication]
+UserName = username
+Password = password
+
 [ServerInformation]
 ServerIPs = ["https://<RedfishIP1>","https://<RedfishIP2>"]
 UserNames = ["Username1","Username2"]


### PR DESCRIPTION
Added the missing [ListenerAuthentication] section to the sample 
configuration with all options. This section was already documented 
in the Configuration section but was missing from the example at 
the end of the README.

This makes the sample configuration complete and consistent with 
the documented options.