### PR TITLE
Add IPv6 listener support

### DIFF
--- a/RedfishEventListener_v1.py
+++ b/RedfishEventListener_v1.py
@@ -6,9 +6,11 @@ import traceback
 import logging
 import json
 import ssl
+import socket
 import sys
 import signal
 import re
+import ipaddress
 from datetime import datetime
 import argparse
 from redfish import redfish_client
@@ -48,6 +50,22 @@ config = {
 }
 
 event_count = {}
+
+
+class IPv6HTTPServer(HTTPServer):
+    """HTTP server configured to bind IPv6 listener addresses."""
+
+    address_family = socket.AF_INET6
+
+
+def get_listener_server_class(listener_ip):
+    """Return the HTTP server class appropriate for a listener IP address."""
+    try:
+        if ipaddress.ip_address(listener_ip).version == 6:
+            return IPv6HTTPServer
+    except ValueError:
+        pass
+    return HTTPServer
 
 
 def parse_list(string: str):
@@ -391,7 +409,8 @@ if __name__ == '__main__':
 
         my_logger.info("Continuing with Listener.")
 
-    event_server = HTTPServer((config['listenerip'], config['listenerport']), RedfishEventListenerServer)
+    server_class = get_listener_server_class(config['listenerip'])
+    event_server = server_class((config['listenerip'], config['listenerport']), RedfishEventListenerServer)
     def clean_subscriptions():
         for name, ctx, unsub_id in target_contexts:
             my_logger.info('\nClosing {}'.format(name))

--- a/config.ini
+++ b/config.ini
@@ -12,6 +12,8 @@ certfile = cert.pem
 keyfile = server.key
 
 [SubscriptionDetails]
+# IPv4: https://<ListenerIP>/
+# IPv6: https://[<ListenerIPv6>]/
 Destination = https://<ListenerIP>/
 Context = Public
 
@@ -20,6 +22,8 @@ UserName = username
 Password = password
 
 [ServerInformation]
+# IPv4: ["https://<RedfishIP>"]
+# IPv6: ["https://[<RedfishIPv6>]"]
 ServerIPs = ["https://<RedfishIP>"]
 UserNames = ["Username1"]
 Passwords = ["Password1"]

--- a/tests/test_server_lifecycle.py
+++ b/tests/test_server_lifecycle.py
@@ -1,6 +1,7 @@
 import sys
 import signal
 import ssl
+import socket
 import pytest
 from unittest.mock import patch, MagicMock, call
 from http.server import HTTPServer
@@ -9,6 +10,18 @@ import RedfishEventListener_v1 as rel
 
 class TestServerLifecycle:
     """Server setup and signal handling tests."""
+
+    def test_ipv4_listener_uses_ipv4_server(self):
+        """An IPv4 listener address selects the default IPv4 server."""
+        server_class = rel.get_listener_server_class("0.0.0.0")
+        assert server_class is HTTPServer
+        assert server_class.address_family == socket.AF_INET
+
+    def test_ipv6_listener_uses_ipv6_server(self):
+        """An IPv6 listener address selects an AF_INET6 server."""
+        server_class = rel.get_listener_server_class("::1")
+        assert server_class is rel.IPv6HTTPServer
+        assert server_class.address_family == socket.AF_INET6
 
     def test_clean_subscriptions(self):
         """Mock contexts, call clean_subscriptions -> all unsubscribed + logged out."""


### PR DESCRIPTION
This enhancement makes the Redfish Event Listener bind successfully to IPv6 listener addresses configured through ListenerIP, including ::, matching the IPv6 behavior documented in the README.

Key Features:
- Added an IPv6 HTTP server class using the AF_INET6 socket family
- Selects the IPv6 server automatically when ListenerIP is an IPv6 address
- Preserves the existing AF_INET HTTP server behavior for IPv4 addresses
- Adds lifecycle tests for IPv4 and IPv6 address-family selection

Changes:
- RedfishEventListener_v1.py: Added IPv6HTTPServer and get_listener_server_class() to select the correct socket family
- tests/test_server_lifecycle.py: Added IPv4 and IPv6 listener server selection tests

This change preserves backward compatibility for existing IPv4 configurations while enabling the documented IPv6 ListenerIP configuration.

Fixes [#48](https://github.com/DMTF/Redfish-Event-Listener/issues/48)